### PR TITLE
Bumps version and removes font declarations

### DIFF
--- a/84em-consent.php
+++ b/84em-consent.php
@@ -3,7 +3,7 @@
  * Plugin Name:     84EM Consent
  * Plugin URI:      https://84em.com/
  * Description:     A WordPress plugin that provides a simple cookie consent banner
- * Version:         1.1.0
+ * Version:         1.1.1
  * Author:          84EM
  * Author URI:      https://84em.com/
  */
@@ -46,7 +46,7 @@ class SimpleConsent {
             'logo_url'           => '',
             'policy_url'         => get_privacy_policy_url() ?: '/privacy-policy/',
             'show_for_logged_in' => false,
-            'cookie_version'     => '2025-09-13',
+            'cookie_version'     => '2025-09-14',
             'banner_text'        => __( 'We use only essential cookies for security and performance.', '84em-consent' ),
             'cookie_duration'    => 180, // days
         ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the 84EM Consent plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2025-09-14
+
+### Removed
+- Removed unnecessary @font-face declarations from CSS
+
 ## [1.1.0] - 2025-09-14
 
 ### Changed

--- a/assets/consent.css
+++ b/assets/consent.css
@@ -9,7 +9,6 @@
     padding: 1rem;
     border-top: 1px solid #2a2a2a;
     z-index: 999999;
-    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
     font-size: 14px;
     line-height: 1.5;
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
@@ -62,7 +61,6 @@
     font-size: 14px;
     transition: opacity 0.2s ease, transform 0.1s ease;
     white-space: nowrap;
-    font-family: inherit;
 }
 
 .e84-consent-button-primary {


### PR DESCRIPTION
Updates plugin version to 1.1.1 and cookie version for new release

Removes explicit font-family declarations from consent banner CSS to inherit theme typography and improve consistency with site design