### PR TITLE
Release v1.2.0 - PHP 8+ syntax refactor and improvements

### DIFF
--- a/84em-consent.php
+++ b/84em-consent.php
@@ -1,13 +1,15 @@
 <?php
 /**
- * Plugin Name:     84EM Consent
- * Plugin URI:      https://84em.com/
- * Description:     A WordPress plugin that provides a simple cookie consent banner
- * Version:         1.1.3
- * Author:          84EM
- * Author URI:      https://84em.com/
- * License:         MIT
- * License URI:     https://opensource.org/licenses/MIT
+ * Plugin Name:         84EM Consent
+ * Plugin URI:          https://84em.com/
+ * Description:         A WordPress plugin that provides a simple cookie consent banner
+ * Version:             1.2.0
+ * Author:              84EM
+ * Requires at least:   6.8
+ * Requires PHP:        8.0
+ * Author URI:          https://84em.com/
+ * License:             MIT
+ * License URI:         https://opensource.org/licenses/MIT
  */
 
 namespace EightyFourEM\Consent;
@@ -18,8 +20,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class SimpleConsent {
 
-    private static $instance = null;
-    private $config = [];
+    private static ?SimpleConsent $instance = null;
+    private array $config;
 
     public static function init() {
         if ( null === self::$instance ) {
@@ -28,20 +30,46 @@ class SimpleConsent {
         return self::$instance;
     }
 
+    /**
+     * Initializes the class by setting up configuration, registering necessary hooks for displaying a banner,
+     * and defining AJAX handlers for user interactions.
+     *
+     * @return void
+     */
     private function __construct() {
         $this->config = $this->get_config();
 
         if ( ! is_admin() && $this->should_show_banner() ) {
-            add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-            add_action( 'wp_footer', [ $this, 'render_banner' ], 100 );
+            add_action(
+                hook_name: 'wp_enqueue_scripts',
+                callback: [ $this, 'enqueue_assets' ]
+            );
+
+            add_action(
+                hook_name: 'wp_footer',
+                callback: [ $this, 'render_banner' ],
+                priority: 100 )
+            ;
         }
 
-        // AJAX handler for dismissal
-        add_action( 'wp_ajax_84em_dismiss_consent', [ $this, 'ajax_dismiss' ] );
-        add_action( 'wp_ajax_nopriv_84em_dismiss_consent', [ $this, 'ajax_dismiss' ] );
+        add_action(
+            hook_name: 'wp_ajax_84em_dismiss_consent',
+            callback: [ $this, 'ajax_dismiss' ]
+        );
+
+        add_action(
+            hook_name: 'wp_ajax_nopriv_84em_dismiss_consent',
+            callback: [ $this, 'ajax_dismiss' ]
+        );
     }
 
-    private function get_config() {
+    /**
+     * Retrieves the configuration for the consent banner, applying filters to modify the default values.
+     *
+     * @return array Returns an associative array of configuration settings including default values such as
+     * Brand name, accent color, logo URL, policy URL, banner text, and cookie duration.
+     */
+    private function get_config(): array {
         $defaults = [
             'brand_name'         => get_bloginfo( 'name' ),
             'accent_color'       => '#CC3000',
@@ -56,13 +84,17 @@ class SimpleConsent {
         return apply_filters( '84em_consent_simple_config', $defaults );
     }
 
-    private function should_show_banner() {
-        // Don't show for logged-in users if configured
+    /**
+     * Determines whether the banner should be displayed based on the current user
+     * state and page context.
+     *
+     * @return bool Returns true if the banner should be displayed, false otherwise.
+     */
+    private function should_show_banner(): bool {
         if ( is_user_logged_in() && ! $this->config['show_for_logged_in'] ) {
             return false;
         }
 
-        // Don't show on privacy policy page
         if ( is_privacy_policy() ) {
             return false;
         }
@@ -70,44 +102,58 @@ class SimpleConsent {
         return true;
     }
 
-    public function enqueue_assets() {
-        // Enqueue minimized CSS
+    /**
+     * Enqueues necessary CSS and JavaScript assets for the plugin, applies custom styles,
+     * and localizes the script with dynamic data for client-side interaction.
+     *
+     * @return void
+     */
+    public function enqueue_assets(): void {
         wp_enqueue_style(
-            '84em-consent',
-            plugin_dir_url( __FILE__ ) . 'assets/consent.min.css',
-            [],
-            $this->config['cookie_version']
+            handle: '84em-consent',
+            src: plugin_dir_url( __FILE__ ) . 'assets/consent.min.css',
+            ver: $this->config['cookie_version']
         );
 
-        // Add custom CSS properties
         $custom_css = sprintf(
             ':root { --e84-consent-accent: %s; }',
             esc_attr( $this->config['accent_color'] )
         );
-        wp_add_inline_style( '84em-consent', $custom_css );
 
-        // Enqueue minimized JS with proper dependencies
-        wp_enqueue_script(
-            '84em-consent',
-            plugin_dir_url( __FILE__ ) . 'assets/consent.min.js',
-            [],
-            $this->config['cookie_version'],
-            [ 'in_footer' => true, 'strategy' => 'async' ],
+        wp_add_inline_style(
+            handle: '84em-consent',
+            data: $custom_css
         );
 
-        // Localize script with configuration
-        wp_localize_script( '84em-consent', 'e84Consent', [
-            'version'     => $this->config['cookie_version'],
-            'duration'    => $this->config['cookie_duration'],
-            'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
-            'nonce'       => wp_create_nonce( '84em-consent-nonce' ),
-            'isSecure'    => is_ssl(),
-            'cookiePath'  => COOKIEPATH,
-            'cookieDomain' => COOKIE_DOMAIN,
-        ] );
+        wp_enqueue_script(
+            handle: '84em-consent',
+            src: plugin_dir_url( __FILE__ ) . 'assets/consent.min.js',
+            ver: $this->config['cookie_version'],
+            args: [ 'in_footer' => true, 'strategy' => 'async' ],
+        );
+
+        wp_localize_script(
+            handle: '84em-consent',
+            object_name: 'e84Consent',
+            l10n: [
+                'version'     => $this->config['cookie_version'],
+                'duration'    => $this->config['cookie_duration'],
+                'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
+                'nonce'       => wp_create_nonce( '84em-consent-nonce' ),
+                'isSecure'    => is_ssl(),
+                'cookiePath'  => COOKIEPATH,
+                'cookieDomain' => COOKIE_DOMAIN,
+            ]
+        );
     }
 
-    public function render_banner() {
+    /**
+     * Renders the HTML structure for a cookie consent banner, including text, buttons,
+     * and optional logo and policy link, with accessibility features.
+     *
+     * @return void
+     */
+    public function render_banner(): void {
         ?>
         <div id="e84-consent-banner"
              class="e84-consent-banner"
@@ -137,7 +183,7 @@ class SimpleConsent {
                             id="e84-consent-accept"
                             class="e84-consent-button e84-consent-button-primary"
                             aria-describedby="e84-consent-text">
-                        <?php esc_html_e( 'OK', '84em-consent' ); ?>
+                        <?php esc_html_e( text: 'OK', domain: '84em-consent' ); ?>
                     </button>
 
                     <?php if ( $this->config['policy_url'] ) : ?>
@@ -145,7 +191,7 @@ class SimpleConsent {
                                 id="e84-consent-learn-more"
                                 class="e84-consent-button e84-consent-button-secondary"
                                 data-url="<?php echo esc_url( $this->config['policy_url'] ); ?>">
-                            <?php esc_html_e( 'Learn More', '84em-consent' ); ?>
+                            <?php esc_html_e( text: 'Learn More', domain: '84em-consent' ); ?>
                         </button>
                     <?php endif; ?>
                 </div>
@@ -154,40 +200,50 @@ class SimpleConsent {
         <?php
     }
 
-    public function ajax_dismiss() {
-        // Verify nonce
+    /**
+     * Handles the dismissal of the cookie consent by verifying the nonce,
+     * setting a server-side cookie as a backup, and sending a successful JSON response.
+     *
+     * @return void
+     */
+    public function ajax_dismiss(): void {
         if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], '84em-consent-nonce' ) ) {
-            wp_die( 'Invalid nonce' );
+            wp_die( message: 'Invalid nonce' );
         }
 
-        // Set cookie server-side as backup
         $duration = $this->config['cookie_duration'] * DAY_IN_SECONDS;
         $secure = is_ssl();
 
         setcookie(
-            '84em_consent',
-            wp_json_encode( [
-                'accepted' => true,
-                'version'  => $this->config['cookie_version'],
+            name: '84em_consent',
+            value: wp_json_encode( [
+                'accepted'  => true,
+                'version'   => $this->config['cookie_version'],
                 'timestamp' => time(),
             ] ),
-            time() + $duration,
-            COOKIEPATH,
-            COOKIE_DOMAIN,
-            $secure,
-            true // httpOnly
+            expires_or_options: time() + $duration,
+            path: COOKIEPATH,
+            domain: COOKIE_DOMAIN,
+            secure: $secure,
+            httponly: true
         );
 
         wp_send_json_success();
     }
 }
 
-// Initialize the plugin
-add_action( 'init', [ __NAMESPACE__ . '\SimpleConsent', 'init' ] );
+add_action(
+    hook_name: 'init',
+    callback: [ '\\EightyFourEM\\Consent\\SimpleConsent', 'init' ]
+);
 
-// Helper function for checking consent
 if ( ! function_exists( 'e84_has_consent' ) ) {
-    function e84_has_consent() {
+    /**
+     * Checks if the user has provided consent based on the presence and content of the consent cookie.
+     *
+     * @return bool Returns true if the consent cookie exists and the 'accepted' field is set to a truthy value, otherwise false.
+     */
+    function e84_has_consent(): bool {
         if ( ! isset( $_COOKIE['84em_consent'] ) ) {
             return false;
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the 84EM Consent plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-10-23
+
+### Added
+- PHP 8+ type hints for properties (nullable and array types)
+- Return type declarations on all methods
+- Comprehensive PHPDoc comments for all methods
+- Named parameters for improved code readability
+
+### Changed
+- Refactored code to use modern PHP 8+ syntax
+- Improved code documentation and inline comments
+
 ## [1.1.3] - 2025-10-23
 
 ### Changed


### PR DESCRIPTION
## Summary
- Refactor codebase to PHP 8+ syntax with type hints and named parameters
- Multiple bug fixes and improvements from versions 1.1.0 through 1.2.0
- Update license from GPL to MIT

## Changes in v1.2.0
- Add PHP 8+ type hints for properties (nullable and array types)
- Add return type declarations on all methods
- Add comprehensive PHPDoc comments
- Refactor to use named parameters throughout

## Previous versions included
- **v1.1.3**: License change to MIT
- **v1.1.2**: Script loading and button contrast improvements
- **v1.1.1**: Remove unnecessary font declarations
- **v1.1.0**: Mobile button layout improvements

## Test plan
- [ ] Verify banner displays correctly for new users
- [ ] Test consent acceptance flow (both localStorage and cookie)
- [ ] Verify PHP 8+ compatibility
- [ ] Check accessibility features (keyboard navigation, ARIA)
- [ ] Test on mobile and desktop viewports
- [ ] Verify "Learn More" link navigation
- [ ] Test consent persistence across page loads