### PR TITLE
v1.3.4 - Fix CSS loading, bump cookie version

### DIFF
--- a/84em-consent.php
+++ b/84em-consent.php
@@ -3,7 +3,7 @@
  * Plugin Name:         84EM Consent
  * Plugin URI:          https://84em.com/
  * Description:         A WordPress plugin that provides a simple cookie consent banner
- * Version:             1.3.3
+ * Version:             1.3.4
  * Author:              84EM
  * Requires at least:   6.8
  * Requires PHP:        8.0
@@ -76,7 +76,7 @@ class SimpleConsent {
             'logo_url'           => '',
             'policy_url'         => get_privacy_policy_url() ?: '/privacy-policy/',
             'show_for_logged_in' => false,
-            'cookie_version'     => '2025-09-15',
+            'cookie_version'     => '2025-12-02',
             'banner_text'        => __( 'We use only essential cookies for security and performance.', '84em-consent' ),
             'cookie_duration'    => 180, // days
         ];
@@ -106,7 +106,7 @@ class SimpleConsent {
      * Enqueues necessary CSS and JavaScript assets for the plugin, applies custom styles,
      * and localizes the script with dynamic data for client-side interaction.
      *
-     * Uses async CSS loading and deferred JavaScript for optimal performance.
+     * Uses deferred JavaScript for optimal performance.
      *
      * @return void
      */
@@ -115,7 +115,7 @@ class SimpleConsent {
             handle: '84em-consent',
             src: plugin_dir_url( __FILE__ ) . 'assets/consent.min.css',
             ver: $this->config['cookie_version'],
-            media: 'print'
+            media: 'all'
         );
 
         $custom_css = sprintf(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the 84EM Consent plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2025-12-02
+### Fixed
+- Fixed CSS not loading due to async `media: 'print'` technique not being handled by theme's async CSS loader
+- Reverted to standard `media: 'all'` for reliable CSS loading
+
+### Changed
+- Bumped cookie_version to 2025-12-02 to trigger re-consent
+
 ## [1.3.3] - 2025-11-25
 ### Fixed
 - Fixed page scroll on first load caused by focus management in consent banner

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ add_filter('84em_consent_simple_config', function($config) {
     $config['accent_color'] = '#D45404';
     $config['banner_text'] = 'We use only essential cookies for security and performance.';
     $config['policy_url'] = '/privacy-policy/';
-    $config['cookie_version'] = '2025-09-13';
+    $config['cookie_version'] = '2025-12-02';
     $config['cookie_duration'] = 180; // days
     $config['show_for_logged_in'] = false;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "84em-consent",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Simple cookie consent banner for 84EM",
   "main": "assets/consent.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Fixed CSS not loading due to async `media: 'print'` technique not being handled by theme's async CSS loader
- Reverted to standard `media: 'all'` for reliable CSS loading
- Bumped cookie_version to 2025-12-02 to trigger re-consent

## Test plan
- [ ] Verify consent banner displays on first visit
- [ ] Verify CSS styles are applied correctly
- [ ] Verify banner dismisses and saves consent
- [ ] Verify banner reappears due to new cookie version